### PR TITLE
Major-update/reading-contents

### DIFF
--- a/macos-app/Sources/App/ContentView.swift
+++ b/macos-app/Sources/App/ContentView.swift
@@ -831,6 +831,12 @@ struct ContentView: View {
                             .buttonStyle(.bordered)
                             .disabled(appState.bloombergPreviewLoading)
 
+                            Toggle("リーダーで開く", isOn: $appState.bloombergUseReaderMode)
+                                .toggleStyle(.switch)
+                                .disabled(appState.bloombergPreviewLoading)
+                                .labelsHidden()
+                                .accessibilityLabel("リーダー表示を強制")
+
                             if appState.bloombergBodySourceURLs.count > 1 {
                                 Text("他 \(appState.bloombergBodySourceURLs.count - 1) 件")
                                     .font(.caption2)

--- a/macos-app/Sources/App/ContentView.swift
+++ b/macos-app/Sources/App/ContentView.swift
@@ -798,24 +798,44 @@ struct ContentView: View {
                     }
                 }
 
-                GroupBox("本文取得対象 URL (\(appState.bloombergBodySourceURLs.count) 件)") {
+                GroupBox("本文取得対象 URL") {
                     if appState.bloombergBodySourceURLs.isEmpty {
                         Text("URL はまだ読み込まれていません")
                             .foregroundStyle(.secondary)
                             .frame(maxWidth: .infinity, alignment: .leading)
-                    } else {
-                        VStack(alignment: .leading, spacing: 6) {
-                            ForEach(appState.bloombergBodySourceURLs.prefix(100), id: \.self) { url in
-                                Text(url)
-                                    .font(.caption)
-                                    .textSelection(.enabled)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                Divider()
+                    } else if let first = appState.bloombergBodySourceURLs.first {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text(first)
+                                .font(.caption)
+                                .textSelection(.enabled)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+
+                        HStack(spacing: 12) {
+                            Button {
+                                appState.openBloombergPreviewInSafari()
+                            } label: {
+                                if appState.bloombergPreviewLoading {
+                                    ProgressView()
+                                } else {
+                                    Label("Safari で開く", systemImage: "safari")
+                                }
                             }
-                            if appState.bloombergBodySourceURLs.count > 100 {
-                                Text("... 他 \(appState.bloombergBodySourceURLs.count - 100) 件")
+                            .buttonStyle(.borderedProminent)
+                            .disabled(appState.bloombergPreviewLoading)
+
+                            Button {
+                                appState.manuallyEnableReaderMode()
+                            } label: {
+                                Label("リーダーを適用", systemImage: "doc.richtext")
+                            }
+                            .buttonStyle(.bordered)
+                            .disabled(appState.bloombergPreviewLoading)
+
+                            if appState.bloombergBodySourceURLs.count > 1 {
+                                Text("他 \(appState.bloombergBodySourceURLs.count - 1) 件")
                                     .font(.caption2)
                                     .foregroundStyle(.secondary)
+                                }
                             }
                         }
                     }

--- a/macos-app/Sources/App/ContentView.swift
+++ b/macos-app/Sources/App/ContentView.swift
@@ -840,6 +840,7 @@ struct ContentView: View {
                         }
                     }
                 }
+
             }
             .padding()
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/macos-app/Sources/App/ContentView.swift
+++ b/macos-app/Sources/App/ContentView.swift
@@ -847,6 +847,55 @@ struct ContentView: View {
                     }
                 }
 
+                GroupBox("解析済みプレビュー") {
+                    if let article = appState.bloombergParsedArticle {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text(article.title)
+                                .font(.title3)
+                                .fontWeight(.semibold)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+
+                            if let dek = article.dek, !dek.isEmpty {
+                                Text(dek)
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            if !article.url.isEmpty {
+                                if let url = URL(string: article.url) {
+                                    Link(article.url, destination: url)
+                                        .font(.caption)
+                                } else {
+                                    Text(article.url)
+                                        .font(.caption)
+                                }
+                            }
+
+                            if let share = article.twitterShareURL, let shareURL = URL(string: share) {
+                                Link("X で共有リンクを開く", destination: shareURL)
+                                    .font(.caption)
+                            }
+
+                            ScrollView {
+                                VStack(alignment: .leading, spacing: 12) {
+                                    ForEach(Array(article.paragraphs.enumerated()), id: \.offset) { _, paragraph in
+                                        Text(paragraph)
+                                            .frame(maxWidth: .infinity, alignment: .leading)
+                                            .font(.body)
+                                            .textSelection(.enabled)
+                                    }
+                                }
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                            .frame(maxHeight: 260)
+                        }
+                    } else {
+                        Text("Safari で記事 HTML を取得するとここに解析結果が表示されます")
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+
             }
             .padding()
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/macos-app/Sources/Resources/SafariReader.applescript
+++ b/macos-app/Sources/Resources/SafariReader.applescript
@@ -1,0 +1,44 @@
+on run argv
+    if (count of argv) = 0 then
+        error "URL argument is required."
+    end if
+    set targetURL to item 1 of argv
+
+    tell application "Safari"
+        activate
+        if (count of documents) = 0 then
+            make new document with properties {URL:"about:blank"}
+        end if
+        set workerWindow to window 1
+        tell workerWindow
+            if (count of tabs) = 0 then
+                set current tab to (make new tab)
+            end if
+            set workerTab to current tab
+            set URL of workerTab to targetURL
+        end tell
+    end tell
+
+    repeat 60 times
+        delay 0.5
+        try
+            tell application "Safari"
+                tell window 1
+                    tell current tab
+                        set readyState to do JavaScript "document.readyState"
+                        if readyState is "complete" then exit repeat
+                    end tell
+                end tell
+            end tell
+        end try
+    end repeat
+
+    delay 0.5
+
+    tell application "System Events"
+        keystroke "r" using {command down, shift down}
+    end tell
+
+    delay 2
+    return "Reader shortcut sent"
+end run

--- a/macos-app/Sources/Resources/SafariReader.applescript
+++ b/macos-app/Sources/Resources/SafariReader.applescript
@@ -3,6 +3,10 @@ on run argv
         error "URL argument is required."
     end if
     set targetURL to item 1 of argv
+    set mode to "reader"
+    if (count of argv) >= 2 then
+        set mode to item 2 of argv
+    end if
 
     tell application "Safari"
         activate
@@ -35,10 +39,14 @@ on run argv
 
     delay 0.5
 
-    tell application "System Events"
-        keystroke "r" using {command down, shift down}
-    end tell
-
-    delay 2
-    return "Reader shortcut sent"
+    if mode is "reader" then
+        tell application "System Events"
+            keystroke "r" using {command down, shift down}
+        end tell
+        delay 1
+        return "Reader shortcut sent"
+    else
+        delay 0.5
+        return "Reader mode skipped"
+    end if
 end run

--- a/macos-app/Sources/Resources/SafariReader.applescript
+++ b/macos-app/Sources/Resources/SafariReader.applescript
@@ -7,20 +7,56 @@ on run argv
     if (count of argv) >= 2 then
         set mode to item 2 of argv
     end if
+    set targetWindowTitle to "AutoBrowsing Worker"
+    if (count of argv) >= 3 then
+        set targetWindowTitle to item 3 of argv
+    end if
+    set placeholderURL to "about:blank"
+    if (count of argv) >= 4 then
+        set placeholderURL to item 4 of argv
+    end if
 
     tell application "Safari"
         activate
         if (count of documents) = 0 then
             make new document with properties {URL:"about:blank"}
         end if
-        set workerWindow to window 1
+        set workerWindow to missing value
+        repeat with w in windows
+            try
+                if name of w is targetWindowTitle then
+                    set workerWindow to w
+                    exit repeat
+                end if
+            end try
+        end repeat
+
+        if workerWindow is missing value then
+            make new document with properties {URL:placeholderURL}
+            set workerWindow to front window
+        end if
+
+        try
+            set name of workerWindow to targetWindowTitle
+        end try
+
         tell workerWindow
             if (count of tabs) = 0 then
                 set current tab to (make new tab)
             end if
             set workerTab to current tab
+            try
+                set URL of workerTab to placeholderURL
+            end try
             set URL of workerTab to targetURL
+            try
+                set name to targetWindowTitle
+            end try
         end tell
+
+        try
+            set index of workerWindow to 1
+        end try
     end tell
 
     repeat 60 times

--- a/macos-app/Sources/Services/Accessibility/SafariAccessibilityController.swift
+++ b/macos-app/Sources/Services/Accessibility/SafariAccessibilityController.swift
@@ -599,6 +599,140 @@ final class SafariAccessibilityController {
         }
     }
 
+    func enableReaderMode() async {
+        Logger.shared.debug("Reader モード切り替えワークフロー開始")
+        guard await waitForReaderAvailability(timeout: 8.0) else {
+            Logger.shared.debug("リーダー表示が利用可能になる前にタイムアウトしました")
+            return
+        }
+        if await setReaderProperty(true) {
+            Logger.shared.debug("Reader モードが有効になりました (direct)")
+            return
+        }
+        Logger.shared.debug("リーダー直接切り替えに失敗したためショートカットを送信します")
+        sendReaderShortcut()
+        if await waitForReaderEnabled(timeout: 5.0) {
+            Logger.shared.debug("Reader モードがショートカットで有効になりました")
+        } else {
+            Logger.shared.debug("Reader モードの有効化に失敗しました")
+        }
+    }
+
+    private func waitForReaderAvailability(timeout: TimeInterval) async -> Bool {
+        let iterations = Int(timeout / 0.3)
+        for i in 0..<max(iterations, 1) {
+            if await isReaderAvailable() {
+                Logger.shared.debug("Reader モード利用可能を確認 (attempt \(i + 1))")
+                return true
+            }
+            try? await Task.sleep(nanoseconds: 300_000_000)
+        }
+        return false
+    }
+
+    private func waitForReaderEnabled(timeout: TimeInterval) async -> Bool {
+        let iterations = Int(timeout / 0.3)
+        for _ in 0..<max(iterations, 1) {
+            if await isReaderEnabled() {
+                return true
+            }
+            try? await Task.sleep(nanoseconds: 300_000_000)
+        }
+        return false
+    }
+
+    private func isReaderAvailable() async -> Bool {
+        let script = tabTellScript(body: "return reader available")
+
+        guard let result = runAppleScript(script)?.stringValue else { return false }
+        if result == "true" || result == "false" {
+            return result == "true"
+        }
+        Logger.shared.debug("reader available の取得に失敗: \(result)")
+        return false
+    }
+
+    private func isReaderEnabled() async -> Bool {
+        let script = tabTellScript(body: "return reader")
+
+        guard let result = runAppleScript(script)?.stringValue else { return false }
+        if result == "true" || result == "false" {
+            return result == "true"
+        }
+        Logger.shared.debug("reader の取得に失敗: \(result)")
+        return false
+    }
+
+    private func setReaderProperty(_ newValue: Bool) async -> Bool {
+        let script = tabTellScript(body: "set reader to \(newValue as NSNumber)" + "\n                    return reader")
+
+        guard let result = runAppleScript(script)?.stringValue else {
+            Logger.shared.debug("reader 設定を呼び出しましたが応答がありません")
+            return false
+        }
+        if result == "true" {
+            return true
+        }
+        Logger.shared.debug("reader 設定に失敗: \(result)")
+        return false
+    }
+
+    private func sendReaderShortcut() {
+        Logger.shared.debug("Reader ショートカット (⌘⇧R) を送信します")
+        let activateScript = """
+        tell application "Safari"
+            try
+                activate
+                return "OK"
+            on error errMsg
+                return "ERROR: " & errMsg
+            end try
+        end tell
+        """
+        _ = runAppleScript(activateScript)
+
+        let script = """
+        tell application "System Events"
+            try
+                tell process "Safari"
+                    keystroke "r" using {command down, shift down}
+                    return "OK"
+                end tell
+            on error errMsg
+                return "ERROR: " & errMsg
+            end try
+        end tell
+        """
+
+        if let result = runAppleScript(script)?.stringValue,
+           result.hasPrefix("ERROR") {
+            Logger.shared.debug("Reader ショートカット送信に失敗: \(result)")
+        } else {
+            Logger.shared.debug("Reader ショートカットを送信しました")
+        }
+    }
+
+    private func tabTellScript(body: String) -> String {
+        let indented = body
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { "            " + $0 }
+            .joined(separator: "\n")
+
+        return """
+tell application "Safari"
+    try
+        tell window 1
+            tell current tab
+\(indented)
+            end tell
+        end tell
+    on error errMsg
+        return "ERROR: " & errMsg
+    end try
+end tell
+"""
+    }
+
     func isMouseCursorInsideSafariWindow() -> Bool {
         guard let frame = safariWindowFrame() else { return false }
         let cursor = currentCursorLocationTopLeftOrigin()

--- a/macos-app/Sources/Services/Accessibility/SafariAccessibilityController.swift
+++ b/macos-app/Sources/Services/Accessibility/SafariAccessibilityController.swift
@@ -37,6 +37,14 @@ final class SafariAccessibilityController {
         return "about:blank"
     }()
 
+    var workerWindowName: String {
+        workerWindowTitle
+    }
+
+    var workerPlaceholderURLString: String {
+        workerPlaceholderURL
+    }
+
     func prepareAccessibilityIfNeeded() throws {
         if !AXIsProcessTrusted() {
             throw AccessibilityNotTrustedError()

--- a/scripts/parse_bloomberg_html.py
+++ b/scripts/parse_bloomberg_html.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Extract Bloomberg article metadata/body from a saved HTML file."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import re
+import sys
+from pathlib import Path
+
+
+NEXT_DATA_PATTERN = re.compile(
+    r'<script id="__NEXT_DATA__" type="application/json">(.*?)</script>',
+    re.DOTALL | re.IGNORECASE,
+)
+
+
+def extract_next_data(payload: str) -> dict:
+    match = NEXT_DATA_PATTERN.search(payload)
+    if not match:
+        raise ValueError("__NEXT_DATA__ block not found in HTML")
+    json_text = html.unescape(match.group(1))
+    try:
+        return json.loads(json_text)
+    except json.JSONDecodeError as exc:
+        raise ValueError("Failed to decode __NEXT_DATA__ JSON") from exc
+
+
+def extract_story(blob: dict) -> dict:
+    try:
+        story = blob["props"]["pageProps"]["story"]
+    except KeyError as exc:
+        raise ValueError("Story payload missing from __NEXT_DATA__ structure") from exc
+    body_blocks = story.get("body", {}).get("content", [])
+    paragraphs: list[str] = []
+    for block in body_blocks:
+        if block.get("type") != "paragraph":
+            continue
+        fragments = block.get("content", [])
+        text = "".join(fragment.get("value", "") for fragment in fragments).strip()
+        if text:
+            paragraphs.append(text)
+    return {
+        "title": story.get("headline"),
+        "dek": story.get("dek"),
+        "url": story.get("url"),
+        "twitterTitle": story.get("twitterTitle"),
+        "twitterDescription": story.get("twitterDescription"),
+        "paragraphs": paragraphs,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("html_path", type=Path, help="Path to saved Bloomberg HTML file")
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        help="Destination JSON file (defaults to <html_path>.parsed.json)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    html_text = args.html_path.read_text(encoding="utf-8")
+    blob = extract_next_data(html_text)
+    story = extract_story(blob)
+    output_path = args.output or args.html_path.with_suffix(".parsed.json")
+    output_path.write_text(
+        json.dumps(story, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    print(f"Saved parsed data to {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
変更概要

Bloomberg 記事の HTML を保存後すぐ __NEXT_DATA__ から解析し、bloomberg_parsed.json を生成・アプリ内に表示できるようにしました。タイトル／デッキ／本文／X 共有 URL を GUI 上で確認できます。
Safari の専用ワーカーウィンドウ識別を安定化。worker-placeholder.html で生成したウィンドウのみを検索・再利用し、常に同じウィンドウで Reader 操作を行います。
CLI からも解析できる scripts/parse_bloomberg_html.py を追加し、任意の保存 HTML から JSON を作れるようにしました。
テスト

swift build (macos-app)
GUI で「Safariで開く」を実行し、bloomberg_parsed.json と UI の解析結果表示を確認